### PR TITLE
Resolves #5

### DIFF
--- a/src/Error/MissingColumnException.php
+++ b/src/Error/MissingColumnException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SoftDelete\Error;
+
+use Cake\Core\Exception\Exception;
+
+class MissingColumnException extends Exception
+{
+}

--- a/src/Model/Table/SoftDeleteTrait.php
+++ b/src/Model/Table/SoftDeleteTrait.php
@@ -17,22 +17,21 @@ trait SoftDeleteTrait {
     public function getSoftDeleteField()
     {
         if (isset($this->softDeleteField)) {
-            if ($this->schema()->column($this->softDeleteField) === null) {
-                throw new MissingColumnException(
-                    __('Configured field `%s` is missing from the table `%s`.',
-                        $this->getSoftDeleteField,
-                        $this->alias()
-                    )
-                );
-            }
-            return $this->softDeleteField;
+            $field = $this->softDeleteField;
+        } else {
+            $field = 'deleted';
         }
 
-        if ($this->schema()->column('deleted') === null) {
-            throw new MissingColumnException(__('Configured field `deleted` is missing from the table `%s`.', $this->alias()));
+        if ($this->schema()->column($field) === null) {
+            throw new MissingColumnException(
+                __('Configured field `{0}` is missing from the table `{1}`.',
+                    $field,
+                    $this->alias()
+                )
+            );
         }
 
-        return 'deleted';
+        return $field;
     }
 
     public function query()

--- a/src/Model/Table/SoftDeleteTrait.php
+++ b/src/Model/Table/SoftDeleteTrait.php
@@ -3,6 +3,7 @@ namespace SoftDelete\Model\Table;
 
 use Cake\ORM\RulesChecker;
 use Cake\Datasource\EntityInterface;
+use SoftDelete\Error\MissingColumnException;
 use SoftDelete\ORM\Query;
 
 trait SoftDeleteTrait {
@@ -11,11 +12,24 @@ trait SoftDeleteTrait {
      * Get the configured deletion field
      *
      * @return string
+     * @throws \SoftDelete\Error\MissingFieldException
      */
     public function getSoftDeleteField()
     {
         if (isset($this->softDeleteField)) {
+            if ($this->schema()->column($this->softDeleteField) === null) {
+                throw new MissingColumnException(
+                    __('Configured field `%s` is missing from the table `%s`.',
+                        $this->getSoftDeleteField,
+                        $this->alias()
+                    )
+                );
+            }
             return $this->softDeleteField;
+        }
+
+        if ($this->schema()->column('deleted') === null) {
+            throw new MissingColumnException(__('Configured field `deleted` is missing from the table `%s`.', $this->alias()));
         }
 
         return 'deleted';

--- a/tests/TestCase/Model/Table/SoftDeleteTraitTest.php
+++ b/tests/TestCase/Model/Table/SoftDeleteTraitTest.php
@@ -3,7 +3,6 @@ namespace SoftDelete\Test\TestCase\Model\Table;
 
 use Cake\TestSuite\TestCase;
 use Cake\ORM\TableRegistry;
-use Cake\Network\Exception\InternalErrorException;
 
 /**
  * App\Model\Behavior\SoftDeleteBehavior Test Case
@@ -258,5 +257,17 @@ class SoftDeleteBehaviorTest extends TestCase
             ->first();
 
         $this->assertEquals(null, $tag);
+    }
+
+    /**
+     * When a configured field is missing from the table, an exception should be thrown
+     *
+     * @expectedException \SoftDelete\Error\MissingColumnException
+     */
+    public function testMissingColumn()
+    {
+        $this->postsTable->softDeleteField = 'foo';
+        $post = $this->postsTable->get(1);
+        $this->postsTable->delete($post);
     }
 }


### PR DESCRIPTION
I've implemented a new exception of `MissingColumnException` for when the soft delete field is missing from the database table. It will also be thrown if a configured field is missing.

I've also added a matching test for it.